### PR TITLE
return ordered sets from 'select many' statements.

### DIFF
--- a/doc/language-reference.rst
+++ b/doc/language-reference.rst
@@ -475,6 +475,27 @@ instances of *CLS* whose attribute *Number* is larger than 100.
 
     .select many inst_set from instances of CLS where (selected.Number > 100)
 
+Ordering Selections
+-------------------
+Instance selections returned by *select many* statement may be ordered by one or
+more instance attributes. The *ordered_by* keyword sorts the resulting set in
+ascending order and the *reverse_ordered_by* keyword sorts the resulting set in
+descending order. If multiple attributes are specified, the set will be sorted
+by the first attribute and then within each value of this, by the second
+attribute and so on. The following example demonstrates how to select all the
+instances of *PERSON* and order them by age first, then alphanumerically by name.
+
+.. code-block:: pyrsl
+
+    .select many people from instances of PERSON ordered_by ( age, name )
+
+The following example demonstrates how to select all the instances of *INVOICE*
+and order them by greatest value.
+
+.. code-block:: pyrsl
+
+    .select many invoices from instances of INVOICE reverse_ordered_by ( value )
+
 Navigating Instances
 --------------------
 Associations between classes may be navigated using the *related by* keyword.

--- a/doc/language-reference.rst
+++ b/doc/language-reference.rst
@@ -487,14 +487,14 @@ instances of *PERSON* and order them by age first, then alphanumerically by name
 
 .. code-block:: pyrsl
 
-    .select many people from instances of PERSON ordered_by ( age, name )
+    .select many people from instances of PERSON ordered_by (age, name)
 
 The following example demonstrates how to select all the instances of *INVOICE*
 and order them by greatest value.
 
 .. code-block:: pyrsl
 
-    .select many invoices from instances of INVOICE reverse_ordered_by ( value )
+    .select many invoices from instances of INVOICE reverse_ordered_by (value)
 
 Navigating Instances
 --------------------

--- a/rsl/ast.py
+++ b/rsl/ast.py
@@ -295,7 +295,15 @@ class SelectAnyInstanceNode(SelectFromNode):
 
 
 class SelectManyInstanceNode(SelectFromNode):
-    pass
+    ordered_by = None
+
+    def __init__(self, variable_name, key_letter, where, ordered_by):
+        super(SelectManyInstanceNode, self).__init__(variable_name, key_letter, where)
+        self.ordered_by = ordered_by
+
+    @property
+    def children(self):
+        return (self.where,self.ordered_by)
 
 
 class SelectOneNode(SelectNode):
@@ -307,7 +315,15 @@ class SelectAnyNode(SelectNode):
 
 
 class SelectManyNode(SelectNode):
-    pass
+    ordered_by = None
+
+    def __init__(self, variable_name, instance_chain, where, ordered_by):
+        super(SelectManyNode, self).__init__(variable_name, instance_chain, where)
+        self.ordered_by = ordered_by
+
+    @property
+    def children(self):
+        return (self.where,self.ordered_by)
 
 
 class RelateNode(Node):
@@ -385,6 +401,18 @@ class WhereNode(Node):
     def children(self):
         return (self.expr,)
         
+class OrderedByNode(Node):
+    reverse = False
+    attributes = list()
+    
+    def __init__(self, reverse=False):
+        self.reverse = reverse
+        self.attributes = list()
+
+    @property
+    def children(self):
+        return iter(self.attributes)
+
 
 class InstanceChainNode(Node):
     variable = None

--- a/rsl/ast.py
+++ b/rsl/ast.py
@@ -295,15 +295,15 @@ class SelectAnyInstanceNode(SelectFromNode):
 
 
 class SelectManyInstanceNode(SelectFromNode):
-    ordered_by = None
+    order_by = None
 
-    def __init__(self, variable_name, key_letter, where, ordered_by):
+    def __init__(self, variable_name, key_letter, where, order_by):
         super(SelectManyInstanceNode, self).__init__(variable_name, key_letter, where)
-        self.ordered_by = ordered_by
+        self.order_by = order_by
 
     @property
     def children(self):
-        return (self.where,self.ordered_by)
+        return (self.where, self.order_by)
 
 
 class SelectOneNode(SelectNode):
@@ -315,15 +315,15 @@ class SelectAnyNode(SelectNode):
 
 
 class SelectManyNode(SelectNode):
-    ordered_by = None
+    order_by = None
 
-    def __init__(self, variable_name, instance_chain, where, ordered_by):
+    def __init__(self, variable_name, instance_chain, where, order_by):
         super(SelectManyNode, self).__init__(variable_name, instance_chain, where)
-        self.ordered_by = ordered_by
+        self.order_by = order_by
 
     @property
     def children(self):
-        return (self.where,self.ordered_by)
+        return (self.where, self.order_by)
 
 
 class RelateNode(Node):
@@ -401,9 +401,9 @@ class WhereNode(Node):
     def children(self):
         return (self.expr,)
         
-class OrderedByNode(Node):
+class OrderByNode(Node):
     reverse = False
-    attributes = list()
+    attributes = None
     
     def __init__(self, reverse=False):
         self.reverse = reverse

--- a/rsl/eval.py
+++ b/rsl/eval.py
@@ -362,7 +362,8 @@ class EvalWalker(xtuml.Walker):
         
     def accept_SelectManyInstanceNode(self, node):
         where = self.accept(node.where)
-        value = self.runtime.select_many_from(node.key_letter, where)
+        order_by = self.accept(node.ordered_by)
+        value = self.runtime.select_many_from(node.key_letter, where, order_by)
         
         self.symtab.install_symbol(node.variable_name, value)
         
@@ -389,7 +390,8 @@ class EvalWalker(xtuml.Walker):
     def accept_SelectManyNode(self, node):
         inst_set = iter(self.accept(node.instance_chain).fget())
         where = self.accept(node.where)
-        value = self.runtime.select_many_in(inst_set, where)
+        order_by = self.accept(node.ordered_by)
+        value = self.runtime.select_many_in(inst_set, where, order_by)
         
         self.symtab.install_symbol(node.variable_name, value)
         
@@ -408,6 +410,13 @@ class EvalWalker(xtuml.Walker):
             return value
             
         return lambda selected: where(node.expr, selected)
+
+    def accept_OrderedByNode(self, node):
+        if len(node.attributes):
+            if node.reverse:
+                return xtuml.reverse_order_by(*node.attributes)
+            else:
+                return xtuml.order_by(*node.attributes)
         
     def accept_InstanceChainNode(self, node):
         inst = self.accept(node.variable).fget()

--- a/rsl/eval.py
+++ b/rsl/eval.py
@@ -362,7 +362,7 @@ class EvalWalker(xtuml.Walker):
         
     def accept_SelectManyInstanceNode(self, node):
         where = self.accept(node.where)
-        order_by = self.accept(node.ordered_by)
+        order_by = self.accept(node.order_by)
         value = self.runtime.select_many_from(node.key_letter, where, order_by)
         
         self.symtab.install_symbol(node.variable_name, value)
@@ -390,7 +390,7 @@ class EvalWalker(xtuml.Walker):
     def accept_SelectManyNode(self, node):
         inst_set = iter(self.accept(node.instance_chain).fget())
         where = self.accept(node.where)
-        order_by = self.accept(node.ordered_by)
+        order_by = self.accept(node.order_by)
         value = self.runtime.select_many_in(inst_set, where, order_by)
         
         self.symtab.install_symbol(node.variable_name, value)
@@ -411,7 +411,7 @@ class EvalWalker(xtuml.Walker):
             
         return lambda selected: where(node.expr, selected)
 
-    def accept_OrderedByNode(self, node):
+    def accept_OrderByNode(self, node):
         if len(node.attributes):
             if node.reverse:
                 return xtuml.reverse_order_by(*node.attributes)

--- a/rsl/parse.py
+++ b/rsl/parse.py
@@ -53,6 +53,8 @@ class RSLParser(object):
               'ENDIF',
               'COMMENT',
               'WHERE',
+              'ORDERED_BY',
+              'REVERSE_ORDERED_BY',
               'ENDFUNCTION',
               'FROMINSTOF',
               'TEXT',
@@ -403,6 +405,16 @@ class RSLParser(object):
     
     def t_control_WHERE(self, t):
         r"(?i)where(?=[\s\(])"
+        t.endlexpos = t.lexpos + len(t.value)
+        return t
+    
+    def t_control_ORDERED_BY(self, t):
+        r"(?i)ordered_by(?=[\s\(])"
+        t.endlexpos = t.lexpos + len(t.value)
+        return t
+
+    def t_control_REVERSE_ORDERED_BY(self, t):
+        r"(?i)reverse_ordered_by(?=[\s\(])"
         t.endlexpos = t.lexpos + len(t.value)
         return t
 
@@ -875,8 +887,8 @@ class RSLParser(object):
         p[0].lineno = p.lineno(0)
     
     def p_selectstatement_3(self, p):
-        """selectstatement : SELECTMANY inst_ref_set_var RELATEDBY inst_chain whereclause"""
-        p[0] = ast.SelectManyNode(p[2], p[4], p[5])
+        """selectstatement : SELECTMANY inst_ref_set_var RELATEDBY inst_chain whereclause orderedby"""
+        p[0] = ast.SelectManyNode(p[2], p[4], p[5], p[6])
         p[0].filename = self.filename
         p[0].lineno = p.lineno(0)
     
@@ -887,8 +899,8 @@ class RSLParser(object):
         p[0].lineno = p.lineno(0)
     
     def p_selectstatement_5(self, p):
-        """selectstatement : SELECTMANY inst_ref_set_var FROMINSTOF obj_keyletters whereclause"""
-        p[0] = ast.SelectManyInstanceNode(p[2], p[4], p[5])
+        """selectstatement : SELECTMANY inst_ref_set_var FROMINSTOF obj_keyletters whereclause orderedby"""
+        p[0] = ast.SelectManyInstanceNode(p[2], p[4], p[5], p[6])
         p[0].filename = self.filename
         p[0].lineno = p.lineno(0)
         
@@ -951,6 +963,34 @@ class RSLParser(object):
         p[0] = ast.WhereNode(p[2])
         p[0].filename = self.filename
         p[0].lineno = p.lineno(0)
+
+    def p_orderedby_1(self, p):
+        """orderedby : """
+        p[0] = ast.OrderedByNode()
+        p[0].filename = self.filename
+        p[0].lineno = p.lineno(0)
+        
+    def p_orderedby_2(self, p):
+        """orderedby : ORDERED_BY LPAREN orderattrs RPAREN"""
+        p[0] = ast.OrderedByNode()
+        p[0].filename = self.filename
+        p[0].lineno = p.lineno(0)
+        p[0].attributes += p[3]
+
+    def p_orderedby_3(self, p):
+        """orderedby : REVERSE_ORDERED_BY LPAREN orderattrs RPAREN"""
+        p[0] = ast.OrderedByNode(True)
+        p[0].filename = self.filename
+        p[0].lineno = p.lineno(0)
+        p[0].attributes += p[3]
+
+    def p_orderattrs_1(self, p):
+        """orderattrs : WORD """
+        p[0] = [p[1]]
+
+    def p_orderattrs_2(self, p):
+        """orderattrs : orderattrs COMMA WORD"""
+        p[0] = p[1] + [p[3]]
     
     def p_fparameters_1(self, p):
         """fparameters : """

--- a/rsl/parse.py
+++ b/rsl/parse.py
@@ -53,8 +53,8 @@ class RSLParser(object):
               'ENDIF',
               'COMMENT',
               'WHERE',
-              'ORDERED_BY',
-              'REVERSE_ORDERED_BY',
+              'ORDER_BY',
+              'REVERSE_ORDER_BY',
               'ENDFUNCTION',
               'FROMINSTOF',
               'TEXT',
@@ -408,12 +408,12 @@ class RSLParser(object):
         t.endlexpos = t.lexpos + len(t.value)
         return t
     
-    def t_control_ORDERED_BY(self, t):
+    def t_control_ORDER_BY(self, t):
         r"(?i)ordered_by(?=[\s\(])"
         t.endlexpos = t.lexpos + len(t.value)
         return t
 
-    def t_control_REVERSE_ORDERED_BY(self, t):
+    def t_control_REVERSE_ORDER_BY(self, t):
         r"(?i)reverse_ordered_by(?=[\s\(])"
         t.endlexpos = t.lexpos + len(t.value)
         return t
@@ -887,7 +887,7 @@ class RSLParser(object):
         p[0].lineno = p.lineno(0)
     
     def p_selectstatement_3(self, p):
-        """selectstatement : SELECTMANY inst_ref_set_var RELATEDBY inst_chain whereclause orderedby"""
+        """selectstatement : SELECTMANY inst_ref_set_var RELATEDBY inst_chain whereclause orderby"""
         p[0] = ast.SelectManyNode(p[2], p[4], p[5], p[6])
         p[0].filename = self.filename
         p[0].lineno = p.lineno(0)
@@ -899,7 +899,7 @@ class RSLParser(object):
         p[0].lineno = p.lineno(0)
     
     def p_selectstatement_5(self, p):
-        """selectstatement : SELECTMANY inst_ref_set_var FROMINSTOF obj_keyletters whereclause orderedby"""
+        """selectstatement : SELECTMANY inst_ref_set_var FROMINSTOF obj_keyletters whereclause orderby"""
         p[0] = ast.SelectManyInstanceNode(p[2], p[4], p[5], p[6])
         p[0].filename = self.filename
         p[0].lineno = p.lineno(0)
@@ -964,22 +964,22 @@ class RSLParser(object):
         p[0].filename = self.filename
         p[0].lineno = p.lineno(0)
 
-    def p_orderedby_1(self, p):
-        """orderedby : """
-        p[0] = ast.OrderedByNode()
+    def p_orderby_1(self, p):
+        """orderby : """
+        p[0] = ast.OrderByNode()
         p[0].filename = self.filename
         p[0].lineno = p.lineno(0)
         
-    def p_orderedby_2(self, p):
-        """orderedby : ORDERED_BY LPAREN orderattrs RPAREN"""
-        p[0] = ast.OrderedByNode()
+    def p_orderby_2(self, p):
+        """orderby : ORDER_BY LPAREN orderattrs RPAREN"""
+        p[0] = ast.OrderByNode()
         p[0].filename = self.filename
         p[0].lineno = p.lineno(0)
         p[0].attributes += p[3]
 
-    def p_orderedby_3(self, p):
-        """orderedby : REVERSE_ORDERED_BY LPAREN orderattrs RPAREN"""
-        p[0] = ast.OrderedByNode(True)
+    def p_orderby_3(self, p):
+        """orderby : REVERSE_ORDER_BY LPAREN orderattrs RPAREN"""
+        p[0] = ast.OrderByNode(True)
         p[0].filename = self.filename
         p[0].lineno = p.lineno(0)
         p[0].attributes += p[3]

--- a/rsl/runtime.py
+++ b/rsl/runtime.py
@@ -279,13 +279,13 @@ class Runtime(object):
     def select_any_from(self, key_letter, where_cond):
         return self.metamodel.select_any(key_letter, where_cond)
          
-    def select_many_from(self, key_letter, where_cond, ordered_by):
-        return self.metamodel.select_many(key_letter, where_cond, ordered_by)
+    def select_many_from(self, key_letter, where_cond, order_by):
+        return self.metamodel.select_many(key_letter, where_cond, order_by)
 
     @staticmethod
-    def select_many_in(inst_set, where_cond, ordered_by):
+    def select_many_in(inst_set, where_cond, order_by):
         s = filter(where_cond, inst_set)
-        return xtuml.QuerySet(s, ordered_by)
+        return xtuml.QuerySet(s, order_by)
 
     @staticmethod
     def select_any_in(inst_set, where_cond):

--- a/rsl/runtime.py
+++ b/rsl/runtime.py
@@ -279,13 +279,13 @@ class Runtime(object):
     def select_any_from(self, key_letter, where_cond):
         return self.metamodel.select_any(key_letter, where_cond)
          
-    def select_many_from(self, key_letter, where_cond):
-        return self.metamodel.select_many(key_letter, where_cond)
+    def select_many_from(self, key_letter, where_cond, ordered_by):
+        return self.metamodel.select_many(key_letter, where_cond, ordered_by)
 
     @staticmethod
-    def select_many_in(inst_set, where_cond):
+    def select_many_in(inst_set, where_cond, ordered_by):
         s = filter(where_cond, inst_set)
-        return xtuml.QuerySet(s)
+        return xtuml.QuerySet(s, ordered_by)
 
     @staticmethod
     def select_any_in(inst_set, where_cond):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -85,6 +85,48 @@ class TestSelect(RSLTestCase):
             self.assertEqual(i, rc)
             self.metamodel.new('A')
 
+    def test_select_many_ordered_by(self):
+        self.metamodel.define_class('A', [('color', 'string'), ('num', 'integer')])
+        self.metamodel.new('A', color='red',    num=0 )
+        self.metamodel.new('A', color='orange', num=1 )
+        self.metamodel.new('A', color='yellow', num=0 )
+        self.metamodel.new('A', color='green',  num=1 )
+        self.metamodel.new('A', color='blue',   num=0 )
+        self.metamodel.new('A', color='purple', num=1 )
+
+        text = '''
+        .select many as from instances of A ordered_by ( num, color )
+        .assign colors = ""
+        .for each a in as
+          .assign colors = "${colors} ${a.color}"
+        .end for
+        .exit colors
+        '''
+
+        rc = self.eval_text(text)
+        self.assertEqual(rc, ' blue red yellow green orange purple')
+
+    def test_select_many_reverse_ordered_by(self):
+        self.metamodel.define_class('A', [('color', 'string'), ('num', 'integer')])
+        self.metamodel.new('A', color='red',    num=0 )
+        self.metamodel.new('A', color='orange', num=1 )
+        self.metamodel.new('A', color='yellow', num=0 )
+        self.metamodel.new('A', color='green',  num=1 )
+        self.metamodel.new('A', color='blue',   num=0 )
+        self.metamodel.new('A', color='purple', num=1 )
+
+        text = '''
+        .select many as from instances of A reverse_ordered_by ( num, color )
+        .assign colors = ""
+        .for each a in as
+          .assign colors = "${colors} ${a.color}"
+        .end for
+        .exit colors
+        '''
+
+        rc = self.eval_text(text)
+        self.assertEqual(rc, ' purple orange green yellow red blue')
+
     def test_select_when_created(self):
         self.metamodel.define_class('A', [])
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -87,15 +87,15 @@ class TestSelect(RSLTestCase):
 
     def test_select_many_ordered_by(self):
         self.metamodel.define_class('A', [('color', 'string'), ('num', 'integer')])
-        self.metamodel.new('A', color='red',    num=0 )
-        self.metamodel.new('A', color='orange', num=1 )
-        self.metamodel.new('A', color='yellow', num=0 )
-        self.metamodel.new('A', color='green',  num=1 )
-        self.metamodel.new('A', color='blue',   num=0 )
-        self.metamodel.new('A', color='purple', num=1 )
+        self.metamodel.new('A', color='red',    num=0)
+        self.metamodel.new('A', color='orange', num=1)
+        self.metamodel.new('A', color='yellow', num=0)
+        self.metamodel.new('A', color='green',  num=1)
+        self.metamodel.new('A', color='blue',   num=0)
+        self.metamodel.new('A', color='purple', num=1)
 
         text = '''
-        .select many as from instances of A ordered_by ( num, color )
+        .select many as from instances of A ordered_by (num, color)
         .assign colors = ""
         .for each a in as
           .assign colors = "${colors} ${a.color}"
@@ -108,15 +108,15 @@ class TestSelect(RSLTestCase):
 
     def test_select_many_reverse_ordered_by(self):
         self.metamodel.define_class('A', [('color', 'string'), ('num', 'integer')])
-        self.metamodel.new('A', color='red',    num=0 )
-        self.metamodel.new('A', color='orange', num=1 )
-        self.metamodel.new('A', color='yellow', num=0 )
-        self.metamodel.new('A', color='green',  num=1 )
-        self.metamodel.new('A', color='blue',   num=0 )
-        self.metamodel.new('A', color='purple', num=1 )
+        self.metamodel.new('A', color='red',    num=0)
+        self.metamodel.new('A', color='orange', num=1)
+        self.metamodel.new('A', color='yellow', num=0)
+        self.metamodel.new('A', color='green',  num=1)
+        self.metamodel.new('A', color='blue',   num=0)
+        self.metamodel.new('A', color='purple', num=1)
 
         text = '''
-        .select many as from instances of A reverse_ordered_by ( num, color )
+        .select many as from instances of A reverse_ordered_by (num, color)
         .assign colors = ""
         .for each a in as
           .assign colors = "${colors} ${a.color}"


### PR DESCRIPTION
for the first pass of this feature, sets are ordered automatically
by the first attribute in the metaclass. note also that this feature
is gated by a command line option. if an 'ordered_by' syntax is ever
added to the RSL language which allows the user to specify the attribute
to order by, the command line option and corresponding infrastructure
should be removed.